### PR TITLE
add support for Satisfactory 1.1

### DIFF
--- a/charts/satisfactory/Readme.md
+++ b/charts/satisfactory/Readme.md
@@ -167,3 +167,53 @@ spec:
                 protocol: UDP
                 endPort: 27050
 ```
+
+## Ingress Configuration
+
+This chart supports ingress configuration with the following options in `values.yaml`:
+
+- `ingress.enabled`: Enable or disable ingress resource creation.
+- `ingress.className`: Specify the ingress class (e.g., nginx, traefik).
+- `ingress.annotations`: Custom annotations for the ingress resource.
+- `ingress.hosts`: List of hosts with paths and path types.
+- `ingress.tls`: TLS configuration with secret names and hosts.
+
+Example ingress configuration in `values.yaml`:
+
+```yaml
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+```
+
+## Extra Ports Configuration
+
+This chart supports extra ports on the service and deployment with the following options:
+
+- `service.extraPortsEnabled`: Boolean flag to enable or disable extra ports.
+- `service.extraPorts`: List of extra ports to expose.
+
+Example extra ports configuration in `values.yaml`:
+
+```yaml
+service:
+  extraPortsEnabled: false
+  extraPorts:
+    - name: extra-tcp
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+```
+
+Set `extraPortsEnabled` to `true` to enable the extra ports defined in `extraPorts`.
+
+---
+
+This completes the documentation update to reflect the recent changes. I will now commit and push this updated README along with any other changed files.

--- a/charts/satisfactory/templates/deployment.yaml
+++ b/charts/satisfactory/templates/deployment.yaml
@@ -23,9 +23,9 @@ spec:
       {{- end }}
       labels:
         {{- include "satisfactory.labels" . | nindent 8 }}
-	{{- with .Values.podLabels }}
+      {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -46,6 +46,13 @@ spec:
             - name: game-udp
               containerPort: {{ .Values.service.port }}
               protocol: UDP
+            {{- if .Values.service.extraPorts }}
+            {{- range .Values.service.extraPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .targetPort }}
+              protocol: {{ .protocol | default "TCP" }}
+            {{- end }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.env }}

--- a/charts/satisfactory/templates/ingress.yaml
+++ b/charts/satisfactory/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "satisfactory.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className }}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "satisfactory.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/satisfactory/templates/service.yaml
+++ b/charts/satisfactory/templates/service.yaml
@@ -31,3 +31,12 @@ spec:
     {{- end }}
   selector:
     {{- include "satisfactory.selectorLabels" . | nindent 4 }}
+
+  {{- if and .Values.service.extraPortsEnabled .Values.service.extraPorts }}
+  {{- range .Values.service.extraPorts }}
+  - port: {{ .port }}
+    targetPort: {{ .targetPort }}
+    protocol: {{ .protocol | default "TCP" }}
+    name: {{ .name }}
+  {{- end }}
+  {{- end }}

--- a/charts/satisfactory/templates/service.yaml
+++ b/charts/satisfactory/templates/service.yaml
@@ -21,5 +21,13 @@ spec:
       targetPort: game-udp
       protocol: UDP
       name: game-udp
+    {{- if .Values.service.extraPorts }}
+    {{- range .Values.service.extraPorts }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol | default "TCP" }}
+      name: {{ .name }}
+    {{- end }}
+    {{- end }}
   selector:
     {{- include "satisfactory.selectorLabels" . | nindent 4 }}

--- a/charts/satisfactory/values.yaml
+++ b/charts/satisfactory/values.yaml
@@ -62,6 +62,11 @@ service:
   #externalIPs:
   #  - 192.168.178.0
   port: 7777
+  extraPorts:
+    - name: extra-tcp
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
 
 
 resources: {}
@@ -105,3 +110,17 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/satisfactory/values.yaml
+++ b/charts/satisfactory/values.yaml
@@ -62,6 +62,7 @@ service:
   #externalIPs:
   #  - 192.168.178.0
   port: 7777
+  extraPortsEnabled: false
   extraPorts:
     - name: extra-tcp
       port: 8888


### PR DESCRIPTION
Satisfactory 1.1 requires port 8888 on TCP. TCP and UDP on 7777 stay the same. Added 8888 under extraports will enable flag. Also, added optional support for ingress via something like nginx.